### PR TITLE
Improve default SECURITY.md template

### DIFF
--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -14,7 +14,7 @@ This project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](
 
 If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
 
-**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
 
 Instead, you can report it using one of the following ways:
 

--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -27,12 +27,14 @@ You can find more information about reporting and disclosure at the [Eclipse Fou
 Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 
 * The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
-* Full paths of source file(s) related to the manifestation of the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Any special configuration required to reproduce the issue
-* Step-by-step instructions to reproduce the issue
-* Proof-of-concept or exploit code (if possible)
+* Affected version(s)
 * Impact of the issue, including how an attacker might exploit the issue
+* Step-by-step instructions to reproduce the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Full paths of source file(s) related to the manifestation of the issue
+* Any special configuration required to reproduce the issue
+* Any log files that are related to this issue (if possible)
+* Proof-of-concept or exploit code (if possible)
 
 This information will help us triage your report more quickly.
 

--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -12,13 +12,29 @@ This project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](
 
 ## How To Report a Vulnerability
 
-If you think you have found a vulnerability in `<project>` you can report it using one of the following ways:
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, you can report it using one of the following ways:
 
 * Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
 * Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
 * [Optional] Report a [vulnerability](https://github.com/<organization>/<repository>/security/advisories/new) directly via private vulnerability reporting on GitHub
 
 You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
 
 ## Supported Versions
 


### PR DESCRIPTION
Up to discussion, this PR adds a bit more text to the default template.

Mainly an explicit note that you should not use public issues, PRs or discussions to report a vulnerability and what to include to triage it more quickly.

This is taken from the standard github SECURITY.md files for their own repos.

If you dont think that this fits for the template, its also ok.