### PR TITLE
Create a SECURITY.md for example code

### DIFF
--- a/templates/example-code-SECURITY.md
+++ b/templates/example-code-SECURITY.md
@@ -16,7 +16,7 @@ If you think you have found a vulnerability in this repository you can report it
 
 * Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
 * Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
-* [Optional] Report a [vulnerability](https://github.com/<organization>/<repository>/security/advisories/new) directly via private vulnerability reporting on GitHub
+* **[If hosting on GitHub]** Report a [vulnerability](https://github.com/<organization>/<repository>/security/advisories/new) directly via private vulnerability reporting on GitHub
 
 You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 

--- a/templates/example-code-SECURITY.md
+++ b/templates/example-code-SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+<!--
+    Adapt this template as needed for your projects. Make sure to replace 
+    `<project>` with your project name.
+
+    For any questions about implementing security best practices, contact the 
+    Eclipse Foundation Security Team at security@eclipse-foundation.org
+-->
+
+This repository adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
+
+## How To Report a Vulnerability
+
+If you think you have found a vulnerability in this repository you can report it using one of the following ways:
+
+* Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
+* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+* [Optional] Report a [vulnerability](https://github.com/<organization>/<repository>/security/advisories/new) directly via private vulnerability reporting on GitHub
+
+You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
+
+## Vulnerability Handling
+
+This repository contains code for educational and / or  demonstration purposes only and **SHOULD NOT** be used for production.
+
+In accordance with the latest [CNA rules](https://www.cve.org/ResourcesSupport/AllResources/CNARules), no CVE IDs will be assigned for vulnerabilities reported to this repository, 
+however the project will strive to fix any reported vulnerability and mention vulnerable released or tagged versions of code in this repository in the 
+[README.md](https://github.com/<organization/<repository>/blob/main/README.md).


### PR DESCRIPTION
As discussed, this PR adds a template for a SECURITY.md for example  / demo code.

The idea is that reporting of a vulnerability should be still enabled and encouraged, however an additional section is added to clarify about the purpose of this repo and how the project will handle such reported vulnerabilities.

Its a first draft, feel free to comment.