### PR TITLE
Add SBOM How-To and Security Mini-Review pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,12 @@ developer/index.md
 ```{toctree}
 :maxdepth: 2
 
+project/index.md
+```
+
+```{toctree}
+:maxdepth: 2
+
 vulnerabilities/index.md
 ```
 

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -1,0 +1,7 @@
+# Project
+
+```{toctree}
+:maxdepth: 1
+
+reviews.md
+```

--- a/docs/project/reviews.md
+++ b/docs/project/reviews.md
@@ -1,0 +1,95 @@
+# Security Mini-Review
+
+A Security Mini Review is a lightweight security assessment designed to help projects strenghten their overall security posture. It provides an easy to use  framework comprising checks from a wide variety of topics, such as: security automation and tooling, secure development practices, incident preparedness, monitoring and visibility, security policies and project setup.
+
+The EF Security Team will be conductiong project mini reviews with the goal of providing guidance and actionable recommendations to help projects strengthen their security posture. Rather than just identifying gaps, we focus on offering clear, practical steps maintainers can take to improve security in meaningful ways. 
+
+We maintain a queue of projects for these reviews, and while we prioritize based on impact and need, we welcome projects that wish to volunteer for a review. If you're interested in having your project assessed, reach out to us and we will do our best to accommodate as many as possible. 
+
+However, if you are eager to get started, we encourage to self-assess using the checklist below.
+
+## Organization section
+
+First section covers project organization level checks, encompassing setup, activity and security team members. Find below a list of these checks, with the one of highest priority marked in bold:
+
+| **CATEGORY**               | **CHECK**                                    |
+|----------------------------|----------------------------------------------|
+| **Setup**                  | **Has own project GitHub organization**      |
+| **Community Health Files** | Has .github repo                             |
+|                            | Has .github/SECURITY.md file                 |
+| **Otterdog**               | Enabled                                      |
+| **Blueprints**             | (global) default-security-policy blueprint   |
+|                            | (global) add-dot-github-repo blueprint       |
+| **Contributions**          | Commits ~1y                                  |
+|                            | Commit Authors ~1y                           |
+|                            | Repositories                                 |
+|                            | Inactive repositories                        |
+|                            | Committers                                   |
+|                            | **Inactive committers**                      |
+| **Security Team**          | **Members**                                  |
+|                            | Last Activity                                |
+|                            | Previous Security Audits                     | 
+
+To check `Otterdog: Blueprients` status, find the project in the [Otterdog Dashboard](https://otterdog.eclipse.org/index) and navigate to the `Blueprints` tab.
+
+In terms of `Contributions`, whilst activity does not always directly influence the security posture of a project, it is a good practice to periodically monitor it. Relevant data can be retrieved from Github or from [Eclipse Metrics](https://metrics.eclipse.org/projects/) by looking up individual projects. Inactive committers should be reviewed on a periodic basis.
+
+The `Project Security Team` members list can be viewed through the [PMI](https://projects.eclipse.org/). 
+
+## Repository section
+
+The second section covers repository specific checks, encompassing topics such as: Vulnerability Reporting and Management, SBOM generation, Static Code Analysis, CI/CD Tooling, Release processes.
+
+| **CATEGORY**               | **CHECK**                                      |
+|----------------------------|-----------------------------------------------|
+| **Vulnerability Reporting** | Private Vulnerability Reporting: Enabled    |
+|                            | Open Reports > 6 months                      |
+|                            | Total Reports                                |
+|                            | Total CVEs                                   |
+| **Vulnerability Management** | Dependabot: Security Alerts Enabled        |
+|                            | -- Resolution                                |
+|                            | -- Triage time                               |
+|                            | -- Unresolved Alerts                         |
+|                            | -- Vulns in Deps: Severity: Critical         |
+|                            | -- Vulns in Deps: Severity: High             |
+| **SBOM**                   | Automated SBOM Generation                    |
+|                            | Upload to DependencyTrack                    |
+|                            | Check dependency tree                        |
+| **Static Analysis**        | Linting                                      |
+|                            | Secret Scanning                              |
+|                            | Secret Exposure Response                     |
+|                            | Unit/Integration Tests                       |
+|                            | Code Coverage                                |
+|                            | License Check                                |
+|                            | Copyright Check                              |
+|                            | ECA Validation                               |
+| **CI/CD: Releases**        | Releases ~1y                                 |
+|                            | Hotfix release practice                      |
+|                            | Stable release policy                        |
+|                            | Publishing destination in README             |
+| **CI/CD: Tools**           | CI/CD Tool/Location enabled                  |
+|                            | Github/Gitlab workflow: Build                |
+|                            | -- zizmor score                              |
+|                            | Eclipse hosted Jenkins                       |
+|                            | Other                                        |
+| **Security Posture**       | Aware of Scorecard report                    |
+|                            | OpenSFF Scorecard Otterdog Integration       |
+|                            | OpenSFF Scorecard                            |
+|                            | -- Branch Protection                         |
+|                            | -- Token-Permissions                         |
+|                            | -- Security Policy (Project specific)        |
+|                            | -- Pinned-Dependencies                       |
+
+While `Vulnerability Reporting` evaluates how the project handles security issues, including the existence of private vulnerability reporting channels, the volume of open reports, and the management of CVEs, `Vulnerability Management` focuses on the project's approach to addressing security risks in its dependencies. This includes the resolution of Dependabot security alerts, the speed of triaging and updating dependencies, and the severity of unresolved issues within the project's supply chain. Together, these categories provide insight into both the project's internal security responsiveness and its proactive stance on dependency security.
+
+The `SBOM` category assesses the project's ability to generate and manage an inventory of its dependencies. This includes automated SBOM generation and integration with our DependencyTrack instance for tracking vulnerabilities and ensuring visibility into the project's dependency tree. 
+
+>If you want to start generating SBOMs for your project, make sure to check out our [How to generate and upload SBOMs](./../sbom/howto.md) guide. There are a lot of other resource available to get your project started, such as [Introduction to SBOM](./../sbom/introduction.md) and [Tooling Ecosystem for CycloneDXM](./../sbom/tooling.md). The EF Security Team is here to support with any SBOM related questions.
+
+The `Static Analysis` category assesses automated tools for linting, secret scanning, unit/integration tests, code coverage, and license/compliance checks. It helps ensure code quality and security by identifying issues early. This category serves as a self-evaluation tool—it's aim is not to provide "good" or "bad" answers, but rather highlight areas where improvements can be made, guiding towards better practices for the project.
+
+The `Releases` evaluates if release periodicity, processes or policies. While we recommend maintaining a regular release schedule, we understand there can be exceptions based on a project's specific needs. This self-evaluation helps projects assess release practices, ensuring that stable policies and clear documentation of publishing destinations are in place, even if releases occur less frequently.
+
+The `CI/CD Tools` category should evaluate the security of tools and workflows used for automating builds and deployments, such as GitHub/GitLab workflows or Jenkins. This self-evaluation does not dictate a specific solution—it highlights the importance of keeping an inventory of such tools as well as evaluating if best security practices are followed. We also encourage using scoring tools specific to your CI/CD tools of choice (example [Zizmor](https://github.com/woodruffw/zizmor) for Github Actions workflows) to evaluate and enhance projects' pipeline security.
+
+The use of automated scoring tools can help in painting the picture of the overall security posture of a project. Such tool is `OpenSSF Scorecard`, which provides an assessment of areas such as branch protection, token permissions and security policy. For more details on how to use the tool, visit the [OpenSSF Scorecard page](https://github.com/ossf/scorecard). To read more about what each check means and how the score is computed, review the [Check Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md). To integrate Scorecard with the self-service, check out [Otterdog Scorecard Integration](https://otterdog.readthedocs.io/en/latest/reference/blueprints/scorecard-integration/).

--- a/docs/sbom/howto.md
+++ b/docs/sbom/howto.md
@@ -1,0 +1,138 @@
+# How to generate and upload SBOMs
+
+This page aims to provide an example approach on how to start generating SBOMs for projects and upload them to our DependencyTrack instance.
+
+## How to generate an SBOM
+Depending on project specifics, one project repository may contain the source code for one or more products. Start by creating a list of products to generate SBOMs for, alongside their corresponding ecosystems and dependency files.
+
+For projects hosted on Github, an easy way to start generating SBOMs, that does not interfere with existing build or releases processes, is through creating a new Github Actions workflow. 
+
+In broad terms, the workflow should:
+* Trigger for:
+    * New releases
+    * Depedency files modified
+* Prepare setup
+    * Checkout the repository
+    * Setup ecosystem specific tooling
+* Generate the SBOM
+    * Use ecosystem specific SBOM generation tooling 
+* Extract metadata
+    * Get product version from SBOM
+* Upload the SBOM as artifact
+
+The implementation of some of the steps above may depend on:
+* product ecosystem
+* project specifics 
+* sbom generation tooling used
+
+SBOMs can be of multiple formats. We recommend generating one in the CycloneDX format as well, as it is the format supported by DependencyTrack platform. For sbom generation, there is a great variety of tooling available that can create the SBOM for you, make sure to take a look at our [Tooling Ecosystem for CycloneDX](tooling.md) guide to choose the tool that best suits your projects' use case. 
+
+For projects that have multiple products, it is advisable to also generate multiple SBOMs, especially if the ecosystems differ. To achieve that, multiple ecosystem specific Github Actions workflows can be created.
+
+
+### Example Workflow: Maven
+This is an example pattern of a Github Actions workflow that creates an SBOM for one maven based product using the [cyclonedx-maven-plugin](https://cyclonedx.github.io/cyclonedx-maven-plugin/):
+
+```
+name: Generate Maven SBOM
+
+# Trigger on new tags created/deps files changes
+on:
+  push:
+    branches: 
+      - "main"
+    paths:
+      - '<PRODUCT_PATH>/pom.xml'
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        default: 'main'
+        required: true
+
+# Product specific settings
+env:
+  JAVA_VERSION: '<java_version>'     # java version used by the product
+  JAVA_DISTRO: '<java_distro>'       # java distro used by the product
+  PRODUCT_PATH: '<PRODUCT_PATH>'     # path within project repository for product source
+  PLUGIN_VERSION: '<plugin_version>' # cyclonedx-maven-plugin version to use
+  SBOM_TYPE: '<makeBom|makeAggregateBom|makePackageBom>' # cyclonedx plugin goal
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }} # required for DependencyTrack upload
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.version }}
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate sbom
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "$PRODUCT_PATH/pom.xml" --settings settings.xml # adapt to project
+        
+      - name: Extract product version
+        id: version
+        shell: bash
+        run: |
+          event="${{ github.event_name }}"
+          ref="${{ github.ref }}"
+          input="${{ github.event.inputs.version }}"
+          VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/target/bom.json)"
+          if [[ "$event" == "push" && "$ref" == refs/heads/* ]] || \
+            [[ "$event" == "workflow_dispatch" && ! "$input" =~ ^v ]]; then
+            VERSION="${VERSION}@dev"
+          fi
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: <artifact_name>
+          path: ${{ env.PRODUCT_PATH }}/target/bom.json
+```
+
+>Make sure dependencies are pinned in Github Actions workflows, as this ensures stability and security by preventing unexpected updates or potential supply chain attacks. An alternative tool that can help in with pinning to commit SHAs is [Octopin](https://github.com/eclipse-csi/octopin)
+
+The `project-version` output is then used in a subsequent job to upload the SBOM to our DependencyTrack instance.
+
+More examples of SBOM Generation workflows for various ecosystems can be found in: [eclipse-csi/workflows](https://github.com/eclipse-csi/workflows)
+
+
+## How to upload an SBOM to DependencyTrack
+
+Once a functional workflow to generate SBOMs is created, the next question that arises is: what to do with them? The SBOM is now uploaded as an artifact for individual workflow runs, however with time searching for specific SBOMs can become tedious.
+
+Our DependencyTrack instance is a centralized place where all EF projects can upload their SBOMs. This way they are easier to find through a web interface, have versioning and are enriched with vulnerability data.
+
+To upload an SBOM to our DependencyTrack instance, first reach out to the EF Security Team with your desired project hierarchy i.e. number of products, their names. We will generate entries and get back to you with a list of `parentProject` IDs.
+
+Then, simply append the below at the end of the SBOM generation workflow. Make sure to the job that generates the SBOM has the name `generate-sbom` and outputs `project-version` with the version of the product.
+
+```
+  store-sbom-data: 
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: '<product_name>' # display name
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: '<artifact_name>' # name from upload in generate-sbom job
+      bomFilename: 'bom.json'
+      parentProject: '<parentProject_ID>' # provisioned by us
+```
+
+`store-sbom-data` stores the SBOM and additional metadata in a predefined format. Otterdog picks the artifacts up upon workflow completion and automatically uploads the SBOM to the DependencyTrack instance.

--- a/docs/sbom/index.md
+++ b/docs/sbom/index.md
@@ -4,5 +4,6 @@
 :maxdepth: 1
 
 introduction.md
+howto.md
 tooling.md
 ```


### PR DESCRIPTION
New pages:
1. SBOM: HowTo
- Guidelines how to generate an SBOM with Github Actions workflows
- Maven example and reference to example workflows repo
- How to start uploading SBOMs to our DepedencyTrack instance through the reusable metadata workflow
2. Security Mini-Reviews
- Introduction
- Checks list with breakdown and resources