### PR TITLE
Add SBOM Registry documentation for users

### DIFF
--- a/docs/sbom/index.md
+++ b/docs/sbom/index.md
@@ -6,5 +6,6 @@
 introduction.md
 howto.md
 tooling.md
+registry.md
 earlyadopters.md
 ```

--- a/docs/sbom/registry.md
+++ b/docs/sbom/registry.md
@@ -1,0 +1,15 @@
+# SBOM Registry
+
+The Eclipse Foundation SBOM registry is a shared platform where projects can upload and manage their SBOMs in one place, using our dedicated [DependencyTrack instance](https://sbom.eclipse.org/).
+
+From a **maintainer** perspective, it removes the overhead of figuring out where and how to store SBOMs by providing a readily available solution with plug-and-play upload integrations.
+
+From a **user** perspective, the registry offers a single location to explore SBOMs across all Eclipse Foundation projects, therefore improving transparency and making it easier to assess the software they depend on.
+
+## How to view project SBOMs
+
+The SBOM registry is available at [sbom.eclipse.org](https://sbom.eclipse.org/). To authenticate, use your **Eclipse Foundation account credentials**. If you do not already have an account, you can create one [here](https://accounts.eclipse.org). 
+
+Once logged in, click on **Projects** and use the search bar on the right side of the platform to locate the project you wish to assess. 
+
+Note that a single project may contain multiple products or components, so the hierarchy may vary between entries. In general, an SBOM should be generated and published by projects for each new release of every component. The registry also retains historical data, allowing users to view SBOMs for past releases as needed.


### PR DESCRIPTION
We need a section on for users only on how to access the SBOM Registry to check out project SBOMs. This can be further appended to READMEs or project documentation once SBOM workflows are merged, to showcase the publishing location. 